### PR TITLE
fix: Release GitHub action.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           release-type: simple


### PR DESCRIPTION
This PR fixes the release action name in the GitHub configuration (https://github.com/googleapis/release-please-action is the new home of the action). 