### PR TITLE
fix: Adds support for Podman on ARM Macs.

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -40,6 +40,9 @@ download_release() {
 
 	os_name=$(uname)
 	platform=$(uname -m)
+	case "$platform" in
+		aarch64) platform=arm64 ;;
+	esac
 	url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}_${os_name}_${platform}.tar.gz"
 
 	echo "* Downloading $TOOL_NAME release $version..."


### PR DESCRIPTION
This PR adds support for Podman on ARM Macs. There, `uname -m` reports `aarch64`, not `arm64`.