### PR TITLE
fix(ci): Adds permissions to GitHub workflows (attempt 2).

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,4 @@ jobs:
         with:
           command: fouskoti version
           gitref: ${{ github.head_ref }}
+          version: 0.7.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request: {}
 
 permissions:
   contents: read
@@ -24,3 +24,4 @@ jobs:
         uses: asdf-vm/actions/plugin-test@v4
         with:
           command: fouskoti version
+          gitref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,4 +24,3 @@ jobs:
         uses: asdf-vm/actions/plugin-test@v4
         with:
           command: fouskoti version
-          gitref: ${{ github.head_ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,4 +24,4 @@ jobs:
         uses: asdf-vm/actions/plugin-test@v4
         with:
           command: fouskoti version
-          gitref: $GITHUB_REF
+          gitref: ${{ github.head_ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,3 +24,4 @@ jobs:
         uses: asdf-vm/actions/plugin-test@v4
         with:
           command: fouskoti version
+          gitref: ${{ github.head_ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,4 +24,4 @@ jobs:
         uses: asdf-vm/actions/plugin-test@v4
         with:
           command: fouskoti version
-          gitref: ${{ github.event.pull_request.head.sha }}
+          gitref: $GITHUB_REF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v4
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request: {}
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   plugin_test:
     name: asdf plugin test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request: {}
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request: {}
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   semantic-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds permissions for the CI workflow, in order to fix the followinf configuration findings:
- https://github.com/sageailabs/asdf-fouskoti/security/code-scanning/1
- https://github.com/sageailabs/asdf-fouskoti/security/code-scanning/2
- https://github.com/sageailabs/asdf-fouskoti/security/code-scanning/3
- https://github.com/sageailabs/asdf-fouskoti/security/code-scanning/4

Now from a well-named branch.